### PR TITLE
Integrate Gemini scheduling

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -3,7 +3,9 @@
 import { generateObject } from "ai"
 import { xai } from "@ai-sdk/xai"
 import { z } from "zod"
+import axios from "axios"
 import type { CalendarEvent } from "./components/weekly-calendar"
+import { readEvents, saveEvents } from "@/lib/events"
 
 // Definimos el esquema que esperamos de la IA
 const eventSchema = z.object({
@@ -69,5 +71,94 @@ export async function processUserInput(
   } catch (error) {
     console.error("Error al generar objeto con la IA:", error)
     return { newEvents: [] }
+  }
+}
+
+// --------- Nuevas funciones con Gemini ---------
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || ""
+
+interface FreeSlot {
+  day: number
+  start: number
+  end: number
+}
+
+function calculateFreeSlots(events: CalendarEvent[]): FreeSlot[] {
+  const DAY_START = 7
+  const DAY_END = 22
+  const slots: FreeSlot[] = []
+
+  for (let day = 0; day < 7; day++) {
+    const dayEvents = events
+      .filter((e) => e.day === day)
+      .sort((a, b) => a.startHour - b.startHour)
+    let start = DAY_START
+    for (const ev of dayEvents) {
+      if (ev.startHour > start) {
+        slots.push({ day, start, end: ev.startHour })
+      }
+      start = Math.max(start, ev.endHour)
+    }
+    if (start < DAY_END) {
+      slots.push({ day, start, end: DAY_END })
+    }
+  }
+  return slots
+}
+
+export async function getEvents(): Promise<{ events: CalendarEvent[] }> {
+  const events = await readEvents()
+  return { events }
+}
+
+export async function addEventFromText(
+  text: string,
+): Promise<{ event: CalendarEvent | null }> {
+  const events = await readEvents()
+  const slots = calculateFreeSlots(events)
+
+  const slotLines = slots
+    .map(
+      (s) => `- Dia ${s.day}, desde ${s.start}:00 hasta ${s.end}:00`,
+    )
+    .join("\n")
+
+  const prompt = `Tengo que organizar mi semana. Mis bloques libres son:\n${slotLines}\nQuiero agendar la siguiente tarea: ${text}.\nResponde solo en JSON con el formato {"title":"tarea","day":numeroDia,"startHour":horaInicio,"endHour":horaFin}.`
+
+  const body = {
+    contents: [
+      {
+        role: "user",
+        parts: [{ text: prompt }],
+      },
+    ],
+  }
+
+  try {
+    const res = await axios.post(
+      `https://generativelanguage.googleapis.com/v1/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`,
+      body,
+    )
+
+    const textResp =
+      res.data?.candidates?.[0]?.content?.parts?.[0]?.text || "{}"
+
+    const obj = JSON.parse(textResp)
+    const newEvent: CalendarEvent = {
+      id: `gemini-${Date.now()}`,
+      title: obj.title || text,
+      day: obj.day,
+      startHour: obj.startHour,
+      endHour: obj.endHour,
+      color: "bg-pink-500",
+    }
+
+    events.push(newEvent)
+    await saveEvents(events)
+
+    return { event: newEvent }
+  } catch (err) {
+    console.error("Error consultando Gemini", err)
+    return { event: null }
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,6 +39,15 @@ export default function Home() {
   const [isProcessing, setIsProcessing] = useState(false)
 
   useEffect(() => {
+    const load = async () => {
+      const { getEvents } = await import("./actions")
+      const { events } = await getEvents()
+      setSchedule(events)
+    }
+    load()
+  }, [])
+
+  useEffect(() => {
     if (schedule.length === 0) return
     setSchedule((prevSchedule) => {
       const newGymStartTime = gymPreference === "mañana" ? 7 : 18
@@ -103,12 +112,11 @@ export default function Home() {
     if (!inputText.trim()) return
     setIsProcessing(true)
     try {
-      // Llama a la acción del servidor para procesar el texto
-      const { processUserInput } = await import("./actions")
-      const { newEvents } = await processUserInput(inputText, schedule)
-
-      // Añade los nuevos eventos al calendario existente
-      setSchedule((prevSchedule) => [...prevSchedule, ...newEvents])
+      const { addEventFromText } = await import("./actions")
+      const { event } = await addEventFromText(inputText)
+      if (event) {
+        setSchedule((prev) => [...prev, event])
+      }
       setInputText("")
     } catch (error) {
       console.error("Error procesando la entrada:", error)

--- a/data/events.json
+++ b/data/events.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "event1",
+    "day": 1,
+    "startHour": 9,
+    "endHour": 10,
+    "title": "Evento Existente 1",
+    "color": "bg-blue-600"
+  },
+  {
+    "id": "event2",
+    "day": 3,
+    "startHour": 14,
+    "endHour": 15,
+    "title": "Evento Existente 2",
+    "color": "bg-green-600"
+  }
+]

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,18 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import type { CalendarEvent } from '@/components/weekly-calendar'
+
+const eventsFile = path.join(process.cwd(), 'data', 'events.json')
+
+export async function readEvents(): Promise<CalendarEvent[]> {
+  try {
+    const data = await fs.readFile(eventsFile, 'utf8')
+    return JSON.parse(data)
+  } catch {
+    return []
+  }
+}
+
+export async function saveEvents(events: CalendarEvent[]) {
+  await fs.writeFile(eventsFile, JSON.stringify(events, null, 2))
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-tooltip": "1.1.6",
     "ai": "latest",
     "autoprefixer": "^10.4.20",
+    "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",


### PR DESCRIPTION
## Summary
- add persistent calendar events file and helpers
- integrate Gemini API to place new events into free slots and save them
- load saved events on startup and allow adding via text box
- include Axios dependency for requests

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68851e29de808322902b866f41ea6dbc